### PR TITLE
Fix the things

### DIFF
--- a/src/videos/components/VideoAdd/VideoAdd.js
+++ b/src/videos/components/VideoAdd/VideoAdd.js
@@ -15,13 +15,13 @@ const VideoAdd = () => (
           Cancel
         </Button>
       </Link>
-      <Link to='/video-search-youtube'>
+      {/* <Link to='/video-search-youtube'>
         <Button
           variant="primary"
           className="btn-mb">
           Search YouTube
         </Button>
-      </Link>
+      </Link> */}
       <Link to='/video-create'>
         <Button
           variant="primary"

--- a/src/videos/convertUrl.js
+++ b/src/videos/convertUrl.js
@@ -6,25 +6,23 @@ const checkUrl = (url) => {
   }
 }
 
+const getParsed = afterWatch => {
+  if (afterWatch[1].substring(0, 11).length === 11) {
+    return afterWatch[1].substring(0, 11)
+  } else {
+    return false
+  }
+}
+
 const parseUrl = url => {
-  let parsed
+  let afterWatch
   if (url.includes('youtube.com')) {
-    const afterWatch = url.split('watch?v=')
-    if (afterWatch[1].substring(0, 11).length === 11) {
-      parsed = afterWatch[1].substring(0, 11)
-    } else {
-      parsed = false
-    }
+    afterWatch = url.split('watch?v=')
   }
   if (url.includes('youtu.be')) {
-    const afterWatch = url.split('.be/')
-    if (afterWatch[1].substring(0, 11).length === 11) {
-      parsed = afterWatch[1].substring(0, 11)
-    } else {
-      parsed = false
-    }
+    afterWatch = url.split('.be/')
   }
-  return parsed
+  return getParsed(afterWatch)
 }
 
 export const createEmbedUrl = (videoId, settings) => {

--- a/src/videos/convertUrl.js
+++ b/src/videos/convertUrl.js
@@ -42,10 +42,11 @@ export const createEmbedUrl = (videoId, settings) => {
     let playlistId
     if (loop === 1) {
       playlistId = videoId
+      return `https://www.youtube.com/embed/${videoId}?autoplay=${auto}&loop=${loop}&playlist=${playlistId}`
     } else {
       playlistId = ''
+      return `https://www.youtube.com/embed/${videoId}?autoplay=${auto}&loop=${loop}`
     }
-    return `https://www.youtube.com/embed/${videoId}?autoplay=${auto}&loop=${loop}&playlist=${playlistId}`
   } else {
     return `https://www.youtube.com/embed/${videoId}`
   }

--- a/src/videos/convertUrl.js
+++ b/src/videos/convertUrl.js
@@ -1,28 +1,21 @@
-let videoId
-
 const checkUrl = (url) => {
-  if (!url.includes('youtube.com') && !url.includes('youtu.be')) {
-    return false
-  }
+  if (!url.includes('youtube.com') && !url.includes('youtu.be')) return false
+  return true
 }
 
-const getParsed = afterWatch => {
-  if (afterWatch[1].substring(0, 11).length === 11) {
+const getParsedUrlID = afterWatch => {
+  if (afterWatch[1] && afterWatch[1].substring(0, 11).length === 11) {
     return afterWatch[1].substring(0, 11)
   } else {
     return false
   }
 }
 
-const parseUrl = url => {
+const parseUrlForID = url => {
   let afterWatch
-  if (url.includes('youtube.com')) {
-    afterWatch = url.split('watch?v=')
-  }
-  if (url.includes('youtu.be')) {
-    afterWatch = url.split('.be/')
-  }
-  return getParsed(afterWatch)
+  if (url.includes('youtube.com')) afterWatch = url.split('watch?v=')
+  if (url.includes('youtu.be')) afterWatch = url.split('.be/')
+  return getParsedUrlID(afterWatch)
 }
 
 export const createEmbedUrl = (videoId, settings) => {
@@ -51,25 +44,13 @@ export const createEmbedUrl = (videoId, settings) => {
 }
 
 const convertUrl = (url, settings) => {
-  if (checkUrl(url) === false) {
-    return false
-  }
-  if (url.includes('youtube.com')) {
-    if (parseUrl(url) === false) {
-      videoId = false
-    } else {
-      videoId = parseUrl(url)
-    }
-  } else if (url.includes('youtu.be')) {
-    if (parseUrl(url) === false) {
-      videoId = false
-    } else {
-      videoId = parseUrl(url)
-    }
-  }
-  if (videoId === false) {
-    return false
-  }
+  // Return false if URL does not include youtube.com or youtu.be
+  if (!checkUrl(url)) return false
+  // Parse URL for video ID. Function returns false if the url doesn't contain a valid ID
+  const videoId = parseUrlForID(url)
+  // Return false if video ID is invalid
+  if (!videoId) return false
+  // Return embedment URL if video ID is valid
   return createEmbedUrl(videoId, settings)
 }
 


### PR DESCRIPTION
Fix for Video unavailable bug:
- Non-looping video URLs cannot have empty "playlist" param any more.
- Added logic to add "playlist" only if we want to loop.

Hide YouTube search button for now, as the feature is unavailable (blocked by API policy).

In URL conversion code:
- Used bang operators.
- Used inline returns.
- Fixed bug for if user entry has no text after "youtube.com".
- Updated function names.
- Removed redundant lines.